### PR TITLE
TRITON-16 Triton APIs should use node v6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/joyent/jsstyle.git
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/joyent/javascriptlint.git
 [submodule "deps/eng"]
 	path = deps/eng
 	url = https://github.com/joyent/eng.git

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright (c) 2019, Joyent, Inc.
+# Copyright 2022 Joyent, Inc.
 #
 
 #
@@ -25,7 +25,7 @@ SMF_MANIFESTS_IN = smf/manifests/registrar.xml.in
 # RELENG-341: no npm cache is making builds unreliable
 NPM_FLAGS :=
 
-NODE_PREBUILT_VERSION=v0.10.48
+NODE_PREBUILT_VERSION=v6.17.0
 ifeq ($(shell uname -s),SunOS)
 	NODE_PREBUILT_TAG=zone
 	# Use sdcnode built for multiarch-15.4.1

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ all: $(SMF_MANIFESTS) | $(NPM_EXEC) $(REPO_DEPS)
 	$(NPM) install
 
 .PHONY: test
-test:
-	@echo "No tests"
+test: all
+	$(NPM) test
 
 .PHONY: release
 release: all $(SMF_MANIFESTS)

--- a/test/zk.test.js
+++ b/test/zk.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2022 Joyent, Inc.
  */
 
 var net = require('net');
@@ -60,6 +60,9 @@ test('start zk client', function (t) {
         t.ifError(err);
         t.ok(client);
         t.equal(typeof (client.heartbeat), 'function');
+        client.on('close', function teardown() {
+            process.exit();
+        });
         client.close(function (err2) {
             t.ifError(err2);
             t.end();


### PR DESCRIPTION
Tests pass:

```
[root@triton-dev-15 ~/src/registrar]# make test
ENGBLD_SKIP_VALIDATE_BUILDENV= \
   /root/src/registrar/deps/eng/tools/validate-buildenv.sh
PATH=/root/src/registrar/build/node/bin:/root/src/binder/build/node/bin:/root/src/binder/node_modules/.bin:/root/opt/go/bin:/root/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin /root/src/registrar/build/node/bin/node /root/src/registrar/build/node/bin/npm install
PATH=/root/src/registrar/build/node/bin:/root/src/binder/build/node/bin:/root/src/binder/node_modules/.bin:/root/opt/go/bin:/root/bin:/opt/local/bin:/opt/local/sbin:/usr/bin:/usr/sbin /root/src/registrar/build/node/bin/node /root/src/registrar/build/node/bin/npm test

> registrar@1.0.0 test /root/src/registrar
> istanbul test test/test.js | ./node_modules/.bin/faucet

✓ setup
✓ healthcheck: create ok
✓ healthcheck: create ok, ignore exit status
✓ healthcheck: create fail check
✓ healthcheck: create fail check by timeout
✓ healthcheck: create fail check by stdout
✓ healthcheck: create fail and mark down
✓ teardown
✓ setup
✓ register: host only
✓ unregister
✓ register: host only with adminIP
✓ register: host only with adminIP+ttl
✓ register: basic with service
✓ register_plus: basic with service
✓ teardown
✓ error with down ZK (and abort)
✓ start zk client
# tests 104
# pass  104
✓ ok
```

Note: I used the 15.4 multi-arch image because rabbitmq is still 32-bit on the 1.6.3 image. After rabbit it updated we can move this to the 19.4 image.

This was also tested by copying it into an existing rabbitmq zone and replacing the existing registrar. After starting up the new registrar, the DNS record populated as expected.