### PR TITLE
TOOLS-2525 Everything needs to stop cloning with git:// URLs (dependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "registrar",
     "description": "Agent to register with binder",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Joyent (joyent.com)",
     "private": true,
     "engines": {
@@ -18,7 +18,7 @@
         "once": "1.3.0",
         "vasync": "1.5.0",
         "verror": "1.4.0",
-        "zkplus": "git+https://github.com/mcavage/node-zkplus.git#7a42e61197fce303b38dd8779c1894a0f3b5d00c"
+        "zkplus": "git+https://github.com/joyent/node-zkplus.git#a0a19240c13155cc9545a476e2b682462dc55d53"
     },
     "devDependencies": {
         "faucet": "0.0.1",


### PR DESCRIPTION
Created a fork of zkplus for our own because I don't know when mcavage would be available to merge in a PR. We also require changes in the git repo that aren't in NPM.